### PR TITLE
Changed locales for date-fns to 46

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you are not using timezone but only a few simple functions from moment.js, th
 | Name                                     | Size(gzip)                        | Tree-shaking | Popularity | Methods richness | Pattern    | Timezone Support      | Locale |
 | ---------------------------------------- | --------------------------------- | ------------ | ---------- | ---------------- | ---------- | --------------------- | ------ |
 | [Moment.js](https://momentjs.com/)       | 329K(69.6K)                       | No           | 38k        | High             | OO         | Good(moment-timezone) | 123    |
-| [date-fns](https://date-fns.org)         | 78.4k(13.4k) without tree-shaking | Yes          | 13k        | High             | Functional | Not yet               | 32     |
+| [date-fns](https://date-fns.org)         | 78.4k(13.4k) without tree-shaking | Yes          | 13k        | High             | Functional | Not yet               | 46     |
 | [dayjs](https://github.com/iamkun/dayjs) | 6.5k(2.6k) without plugins        | No           | 14k        | Medium           | OO         | Not yet               | 23     |
 
 ## Voice of Developers


### PR DESCRIPTION
As per their website, they support 46 locales. However docs. does specify the old number. I'm unaware which is correct, just wanted to add this here in case.

![screenshot 2018-09-26 10 50 53](https://user-images.githubusercontent.com/2689341/46068811-4d309300-c17a-11e8-99cd-0ee8e5909f46.png)
