### PR TITLE
fix native sample for add

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,15 +569,8 @@ moment().add(7, 'days');
 // => "2018-09-16T09:12:49.695Z"
 
 // Native
-new Date(
-  new Date().getFullYear(),
-  new Date().getMonth() + 1,
-  new Date().getDate() + 7,
-  new Date().getHours(),
-  new Date().getMinutes(),
-  new Date().getSeconds(),
-  new Date().getMilliseconds()
-);
+const now = new Date();
+now.setDate(now.getDate() + 7);
 // => "Sun Sep 16 2018 09:12:49"
 
 // date-fns
@@ -592,10 +585,10 @@ dayjs().add(7, 'day');
 
 | Library | Time       |
 | ------- | ---------- |
-| Moment  | 1673.028ms |
-| Native  | 2325.192ms |
-| DateFns | 800.039ms  |
-| DayJs   | 1007.254ms |
+| Moment  | 1468.151ms |
+| Native  | 208.735ms  |
+| DateFns | 337.129ms  |
+| DayJs   | 631.982ms  |
 
 **[⬆ back to top](#quick-links)**
 

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -220,15 +220,8 @@ describe('Manipulate', () => {
   it('Add', () => {
     const m = moment(time).add(7, 'days');
     const d = date.addDays(new Date(time), 7);
-    const n = new Date(
-      new Date(time).getFullYear(),
-      new Date(time).getMonth(),
-      new Date(time).getDate() + 7,
-      new Date(time).getHours(),
-      new Date(time).getMinutes(),
-      new Date(time).getSeconds(),
-      new Date(time).getMilliseconds()
-    );
+    const n = new Date(time);
+    n.setDate(n.getDate() + 7);
     const day = dayjs(time).add(7, 'day');
     expect(m.valueOf()).toBe(d.getTime());
     expect(m.valueOf()).toBe(day.valueOf());

--- a/__tests__/performance.js
+++ b/__tests__/performance.js
@@ -295,15 +295,8 @@ const Add = {
   },
   native: () => {
     performanceTest('Native', () => {
-      new Date(
-        new Date().getFullYear(),
-        new Date().getMonth() + 1,
-        new Date().getDate() + 7,
-        new Date().getHours(),
-        new Date().getMinutes(),
-        new Date().getSeconds(),
-        new Date().getMilliseconds()
-      );
+      const now = new Date();
+      now.setDate(now.getDate() + 7);
     });
   },
   dateFns: () => {


### PR DESCRIPTION
Querying all the date items is rather slow for the native solution, so I propose this much faster one that yields the same result in far less time. I tested the performance on a core i7 5th generation and updated the results only for add.