### PR TITLE
Add native implementation for end of time

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,6 +661,12 @@ Return the end of a unit of time for the given date.
 moment().endOf('day');
 // => "2018-09-09T13:59:59.999Z"
 
+// Native
+const end = new Date();
+end.setHours(23, 59, 59, 999);
+end.toISOString();
+// => "2018-09-09T16:59:59.999Z"
+
 // date-fns
 import endOfDay from 'date-fns/endOfDay';
 endOfDay(new Date());
@@ -673,10 +679,10 @@ dayjs().endOf('day');
 
 | Library | Time       |
 | ------- | ---------- |
-| Moment  | 4575.466ms |
-| Native  | -          |
-| DateFns | 649.161ms  |
-| DayJs   | 1617.489ms |
+| Moment  | 5180.706ms |
+| Native  | 272.112ms  |
+| DateFns | 386.81ms   |
+| DayJs   | 1131.517ms |
 
 **[⬆ back to top](#quick-links)**
 
@@ -821,7 +827,7 @@ dayjs('2010-10-20').isBefore('2010-10-21');
 
 ### Is Same
 
-Check if a date is same another date.
+Check if a date is the same as another date.
 
 ```js
 // Moment.js

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -252,8 +252,11 @@ describe('Manipulate', () => {
 
   it('End of Time', () => {
     const m = moment(time).endOf('day');
+    const n = new Date(time);
+    n.setHours(23, 59, 59, 999);
     const d = date.endOfDay(new Date(time));
     const day = dayjs(time).endOf('day');
+    expect(m.valueOf()).toBe(n.valueOf());
     expect(m.valueOf()).toBe(d.getTime());
     expect(m.valueOf()).toBe(day.valueOf());
   });

--- a/__tests__/performance.js
+++ b/__tests__/performance.js
@@ -364,6 +364,12 @@ const EndOfTime = {
       moment().endOf('day');
     });
   },
+  native: () => {
+    performanceTest('Native', () => {
+      const end = new Date();
+      end.setHours(23, 59, 59, 999);
+    });
+  },
   dateFns: () => {
     performanceTest('DateFns', () => {
       endOfDay(new Date());


### PR DESCRIPTION
Btw, the `fromNow` test is breaking on my side because `dayjs/plugin/relativeTime` [convert _26 days_ to _a month_](https://github.com/iamkun/dayjs/blob/d08269cefc2c0f92e16e48a70adad797f9b78f0a/docs/en/Plugin.md)