### PR TITLE
fix same

### DIFF
--- a/README.md
+++ b/README.md
@@ -1007,9 +1007,13 @@ moment('2010-10-20').isSame('2010-10-21', 'month');
 // => true
 
 // Native
-new Date(2010, 9, 20) === new Date(2010, 9, 21);
+new Date(2010, 9, 20).valueOf() === new Date(2010, 9, 21).valueOf();
 // => false
-new Date(2010, 9, 20) === new Date(2010, 9, 20);
+new Date(2010, 9, 20).valueOf() === new Date(2010, 9, 20).valueOf();
+// => true
+new Date(2010, 9, 20).getTime() === new Date(2010, 9, 20).getTime();
+// => true
+new Date(2010, 9, 20).valueOf() === new Date(2010, 9, 20).getTime();
 // => true
 new Date(2010, 9, 20).toDateString().substring(4, 7) ===
   new Date(2010, 9, 21).toDateString().substring(4, 7);

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -509,6 +509,15 @@ describe('Query', () => {
 
     expect(moment('2010-10-20').isSame('2010-10-21', 'month')).toBeTruthy();
     expect(
+      new Date(2010, 9, 20).valueOf() === new Date(2010, 9, 20).valueOf()
+    ).toBeTruthy();
+    expect(
+      new Date(2010, 9, 20).getTime() === new Date(2010, 9, 20).getTime()
+    ).toBeTruthy();
+    expect(
+      new Date(2010, 9, 20).valueOf() === new Date(2010, 9, 20).getTime()
+    ).toBeTruthy();
+    expect(
       new Date(2010, 9, 20).toDateString().substring(4, 7) ===
         new Date(2010, 9, 21).toDateString().substring(4, 7)
     ).toBeTruthy();


### PR DESCRIPTION
Native under Is Same is wrong:

```js
// Native
new Date(2010, 9, 20) === new Date(2010, 9, 21);
// => false
new Date(2010, 9, 20) === new Date(2010, 9, 20);
// => true
```

To compare native JavaScript dates one needs to use `.getTime()` or `.valueOf()`. The first entry above happens to be false but that is due to object equality. The other lines don't return the above result on a couple of JavaScript engines:

node v8.14.0:
```
> new Date(2010, 9, 20) === new Date(2010, 9, 20);
false
```
Chrome 70.0.3538.110:
```
new Date(2010, 9, 20) === new Date(2010, 9, 20);
false
```

Firefox 64.0:
```
new Date(2010, 9, 20) === new Date(2010, 9, 20);
false
```

I've added the missing tests for this too along with examples of using `.valueOf()`, `.getTime()` or even a mix of `.valueOf()` and `.getTime()` to compare date equality.