### PR TITLE
fix dayjs isLeapYear to match dayjs IsLeapYear API doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1128,7 +1128,7 @@ isLeapYear(new Date(2000, 0, 1));
 // dayjs ⚠️ requires isLeapYear plugin
 import isLeapYear from 'dayjs/plugin/isLeapYear';
 dayjs.extend(isLeapYear);
-dayjs('2000').isLeapYear();
+dayjs('2000-01-01').isLeapYear();
 // => true
 
 // luxon

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -561,8 +561,8 @@ describe('Query', () => {
     expect(new Date(2000, 1, 29).getDate() === 29).toBeTruthy();
     expect(date.isLeapYear(new Date(2000, 0, 1))).toBeTruthy();
     expect(date.isLeapYear(new Date(2001, 0, 1))).toBeFalsy();
-    expect(dayjs('2000').isLeapYear()).toBeTruthy();
-    expect(dayjs('2001').isLeapYear()).toBeFalsy();
+    expect(dayjs('2000-01-01').isLeapYear()).toBeTruthy();
+    expect(dayjs('2001-01-01').isLeapYear()).toBeFalsy();
     expect(DateTime.local(2000).isInLeapYear).toBeTruthy();
     expect(DateTime.local(2001).isInLeapYear).toBeFalsy();
   });


### PR DESCRIPTION
dayjs under Is Leap Year is wrong:

```js
// dayjs ⚠️ requires isLeapYear plugin
import isLeapYear from 'dayjs/plugin/isLeapYear';
dayjs.extend(isLeapYear);
dayjs('2000').isLeapYear();
```

At least for me, on OS X, the test is not being truthy so it is failing. According to the [IsLeapYear API documentation](https://github.com/iamkun/dayjs/blob/master/docs/en/Plugin.md#isleapyear), it appears to expect a `YYYY-MM-DD` string.

I updated the tests to match the API documentation and they passed. I updated the example in the README too.