### PR TITLE
add a note to native Days in Month

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,7 +540,7 @@ Get the number of days in the current month.
 moment('2012-02', 'YYYY-MM').daysInMonth();
 // => 29
 
-// Native
+// Native (note that while JavaScript months are zero-based, the month for this purpose must be the month after the desired month)
 new Date(2012, 02, 0).getDate();
 // => 29
 


### PR DESCRIPTION
Not sure on the exact wording but native days in month is confusing because the second parameter to `Date` is normally zero-based month however in this case, we need the number for the month after the desired month. In other words, December === 11 with zero-based but if we want number of days in December, we have to pass in 12.

Example:

```console
new Date(2018, 11, 0).getDate()
> 30
new Date(2018, 12, 0).getDate()
> 31
```
