### PR TITLE
(fix):fix broken build - use yyyy instead of YYYY

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -396,7 +396,7 @@ describe('Manipulate', () => {
 describe('Display', () => {
   it('Format', () => {
     const m = moment(time).format('dddd, MMMM D YYYY, h:mm:ss A');
-    const d = date.format(new Date(time), 'eeee, MMMM d YYYY, h:mm:ss aa', {
+    const d = date.format(new Date(time), 'eeee, MMMM d yyyy, h:mm:ss aa', {
       awareOfUnicodeTokens: true,
     });
     const day = dayjs(time).format('dddd, MMMM D YYYY, h:mm:ss A');


### PR DESCRIPTION


https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md


![Screen Shot 2019-08-10 at 11 38 08 am](https://user-images.githubusercontent.com/4587603/62815946-63152f80-bb63-11e9-9cba-9d9a80a647ec.png)
