### PR TITLE
Update Day.js info

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you are not using timezone but only a few simple functions from moment.js, th
 | [Moment.js](https://momentjs.com/)       | 329K(69.6K)                       | No           | 42.1k             | High             | OO         | Good(moment-timezone) | 123    |
 | [Luxon](https://moment.github.io/luxon/) | 59.9K(17.2K)                      | No           | 8.6k              | High             | OO         | Good(Intl)            | -      |
 | [date-fns](https://date-fns.org)         | 78.4k(13.4k) without tree-shaking | Yes          | 19k               | High             | Functional | Not yet               | 50     |
-| [dayjs](https://github.com/iamkun/dayjs) | 6.5k(2.6k) without plugins        | No           | 22.9k             | High             | OO         | Not yet               | 130    |
+| [dayjs](https://github.com/iamkun/dayjs) | 6.5k(2.6k) without plugins        | No           | 23k             | High             | OO         | Not yet               | 130    |
 
 ## Voice of Developers
 
@@ -141,7 +141,7 @@ npm install --save-dev eslint-plugin-you-dont-need-momentjs
 | Day of Year                    | ✅     | ✅    | ✅       | ✅    |
 | Week of Year                   | ✅     | ✅    | ✅       | ⚠️    |
 | Days in Month                  | ✅     | ✅    | ✅       | ⚠️    |
-| Weeks in Year                  | ❌     | ❌    | ✅       | ❌    |
+| Weeks in Year                  | ❌     | ❌    | ✅       | ⚠️    |
 | Maximum of the given dates     | ✅     | ✅    | ✅       | ⚠️    |
 | Minimum of the given dates     | ✅     | ✅    | ✅       | ⚠️    |
 |                                |        |       |          |       |


### PR DESCRIPTION
Hi,
According to the "Weeks in Year" section below, dayjs ⚠️ requires isoWeeksInYear plugin to support this not "NOT support"

THX