### PR TITLE
Add native `RelativeTimeFormat` to `display` section `Time from now` item

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 node_js:
-  - 8
-  - 10
-  - 11
   - 12
+  - 13
+  - 14
 after_success:
   - npm run coveralls

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ npm install --save-dev eslint-plugin-you-dont-need-momentjs
 |                                |        |       |          |       |
 | **Display**                    |        |       |          |       |
 | Format                         | ❌     | ✅    | ✅       | ✅    |
-| Time from now                  | ❌     | ❌    | ✅       | ⚠️    |
+| Time from now                  | ✅     | ❌    | ✅       | ⚠️    |
 | Time from X                    | ❌     | ❌    | ✅       | ⚠️    |
 | Difference                     | ✅     | ✅    | ✅       | ✅    |
 |                                |        |       |          |       |
@@ -955,6 +955,10 @@ Return time from now.
 ```js
 // Moment.js
 moment(1536484369695).fromNow();
+// => "4 days ago"
+
+// Native
+new Intl.RelativeTimeFormat().format(4, 'day');
 // => "4 days ago"
 
 // date-fns

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -425,12 +425,14 @@ describe('Display', () => {
       new Date(new Date().getFullYear(), new Date().getMonth() + 1, 0).getDate()
     );
     const m = moment(timeDistance).fromNow();
+    const n = new Intl.RelativeTimeFormat().format(-3, 'month');
     const d = date.formatDistanceStrict(new Date(timeDistance), new Date(), {
       addSuffix: true,
     });
     const day = dayjs(timeDistance).fromNow(); // plugin
     expect(m).toBe(d);
     expect(m).toBe(day);
+    expect(m).toBe(n);
   });
 
   it('Time from X', () => {


### PR DESCRIPTION
A test failure is expected on Node.js v10 (non-active LTS). Adding a polyfill or removing v10 from travis matrix could resolve the problem.
https://nodejs.org/en/about/releases/

The test would fail on Safari 13- according to
https://caniuse.com/#search=Intl%3A%20RelativeTimeFormat%3A%20format