### PR TITLE
Remove a non-existent testimonial

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,6 @@ If you are not using timezone but only a few simple functions from moment.js, th
 
 > &mdash;<cite>Matija Marohnić, a design-savvy frontend developer from Croatia.</cite>
 
-> [Just yesterday changed momentjs to this lib in out project. Cut the size of our js bundle almost in half 😱](https://twitter.com/gribnoysup/status/805061630752997377)
-
-> &mdash;<cite>Sergey Petushkov, a javaScript developer from Moscow, Russia • Currently in Berlin, Germany.</cite>
-
 ## ESLint Plugin
 
 <p align="center">


### PR DESCRIPTION
The tweet is unavailable now. I guess it was deleted. So I think it should be removed from here as well since people reading this doc who click on it would find nothing anyway.