### PR TITLE
Replace date-fns's format() with new intlFormat() 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1021,11 +1021,11 @@ new Intl.DateTimeFormat('en-US', { weekday: 'short', hour: 'numeric' }).format(n
 // => "Sun, 7 PM"
 
 // date-fns
-import format from 'date-fns/format';
-format(new Date(), 'eeee, MMMM do YYYY, h:mm:ss aa');
-// => "Sunday, September 9th 2018, 7:12:49 PM"
-format(new Date(), 'eee, ha');
-// => "Sun, 7PM"
+import { intlFormat } from 'date-fns'
+intlFormat(new Date(), { dateStyle: 'full', timeStyle: 'medium' }, { locale: 'en-US', })
+// => "Sunday, September 9, 2018 at 7:12:49 PM"
+intlFormat(new Date(), { weekday: 'short', hour: 'numeric' }, { locale: 'en-US', })
+// => "Sun, 7 PM"
 
 // dayjs
 dayjs().format('dddd, MMMM D YYYY, h:mm:ss A');


### PR DESCRIPTION
available since ~Feb 2021 https://github.com/date-fns/date-fns/releases/tag/v2.17.0

> a lightweight formatting function that uses [Intl API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl). Eventually, it will become the default formatting function, so it's highly recommended for new code.

https://date-fns.org/v2.28.0/docs/intlFormat