### PR TITLE
Feature: Ability to customize the message

### DIFF
--- a/lib/__tests__/index.js
+++ b/lib/__tests__/index.js
@@ -26,9 +26,10 @@ describe('ESLint plugin', () => {
       },
       {
         code: "(async () => { const m = await import('moment'); })()",
+        options: [{ suggestedAlternative: 'luxon' }],
         errors: [
           {
-            message: 'Use date-fns or Native Date methods instead of moment.js',
+            message: 'Use luxon instead of moment.js',
             type: 'CallExpression',
           },
         ],

--- a/lib/rules/no-dynamic-import-moment.js
+++ b/lib/rules/no-dynamic-import-moment.js
@@ -1,4 +1,8 @@
-var message = 'Use date-fns or Native Date methods instead of moment.js';
+function message(options = []) {
+  const suggestedAlternative = options[0] && options[0].suggestedAlternative;
+  return `Use ${suggestedAlternative ||
+    'date-fns or Native Date methods'} instead of moment.js`;
+}
 
 module.exports = function(context) {
   return {
@@ -10,7 +14,7 @@ module.exports = function(context) {
       var arg = node.arguments[0];
 
       if (arg.type === 'Literal' && arg.value === 'moment') {
-        context.report(node, message);
+        context.report(node, message(context.options));
       }
     },
   };


### PR DESCRIPTION
My team already knows that the transition we're making is from `moment` to `luxon`.  With many developers, it would be more clear if the error messages didn't suggest `date-fns`.

This PR adds the ability to customize the message for a specific suggestion.  I only did it for one rule for the purposes of proposal; if y'all approve this approach I can generalize it for the remaining rules!